### PR TITLE
PropertyUtils.addBeanIntrospector(new FluentPropertyBeanIntrospector());

### DIFF
--- a/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/system/query/QueryGenerator.java
+++ b/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/system/query/QueryGenerator.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.beanutils.FluentPropertyBeanIntrospector;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.jeecg.common.system.util.JeecgDataAutorUtils;
 import org.jeecg.common.system.util.JwtUtil;
@@ -29,6 +30,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class QueryGenerator {
+	static {
+		PropertyUtils.addBeanIntrospector(new FluentPropertyBeanIntrospector());
+	}
 	
 	public static final String SQL_RULES_COLUMN = "SQL_RULES_COLUMN";
 	

--- a/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/util/TrimUtil.java
+++ b/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/util/TrimUtil.java
@@ -1,0 +1,51 @@
+package org.jeecg.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.beanutils.FluentPropertyBeanIntrospector;
+import org.apache.commons.beanutils.PropertyUtils;
+
+import java.beans.PropertyDescriptor;
+
+@Slf4j
+public class TrimUtil {
+    static {
+//        Thread.dumpStack();
+        PropertyUtils.addBeanIntrospector(new FluentPropertyBeanIntrospector());
+    }
+    public static void trimObj(Object obj){
+//        Thread.dumpStack();
+        PropertyDescriptor origDescriptors[] = PropertyUtils.getPropertyDescriptors(obj);
+        String name, type;
+        for (int i = 0; i < origDescriptors.length; i++) {
+            name = origDescriptors[i].getName();
+            type = origDescriptors[i].getPropertyType().toString();
+            try {
+                if (judgedIsUselessField(name)|| !PropertyUtils.isReadable(obj, name)) {
+                    continue;
+                }
+                Object value = PropertyUtils.getSimpleProperty(obj, name);
+                if (value != null && value instanceof String) {
+                    String val = (value).toString().trim(); //trim 去除空格
+//                    log.info(" obj : |{}|,  name : |{}|, val : |{}|", obj.getClass(), name, val);
+                    PropertyUtils.setSimpleProperty(obj, name, val);
+                }
+            } catch (Exception e) {
+              log.error(e.getMessage(),e);
+            } finally {
+            }
+        }
+    }
+
+    /**
+     *
+     * @param name
+     * @return
+     */
+    private static boolean judgedIsUselessField(String name) {
+        return "class".equals(name) || "ids".equals(name)
+                || "page".equals(name) || "rows".equals(name)
+                || "sort".equals(name) || "order".equals(name);
+    }
+
+
+}


### PR DESCRIPTION
【问题描述】

数据新增时，需要 trim，写了个 通用的 trim 类，
参考 QueryGenerator.java 写的，结果报错: 
java.lang.NoSuchMethodException: Property 'xxx' has no setter method in class 'class org.jeecg.modules.xxx.entity.xxx'

【原因如下】
BeanUtils not works for chain setter

https://www.manongdao.com/article-780682.html

【解决方案】
添加
	static {
		PropertyUtils.addBeanIntrospector(new FluentPropertyBeanIntrospector());
	}

【注意】
在 QueryGenerator.java 里也必须添加

	static {
		PropertyUtils.addBeanIntrospector(new FluentPropertyBeanIntrospector());
	}

查看 PropertyUtils 源码：	
	
    public static PropertyDescriptor[] getPropertyDescriptors(final Object bean) {
        return PropertyUtilsBean.getInstance().getPropertyDescriptors(bean);
    }
	
这里用了单例模式： PropertyUtilsBean.getInstance()