### PR TITLE
Update ShiroConfig.java

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java
@@ -290,7 +290,7 @@ public class ShiroConfig {
             RedisSentinelManager sentinelManager = new RedisSentinelManager();
             sentinelManager.setMasterName(redisProperties.getSentinel().getMaster());
             sentinelManager.setHost(String.join(",", redisProperties.getSentinel().getNodes()));
-            sentinelManager.setPassword(redisProperties.getSentinel().getPassword());
+            sentinelManager.setPassword(redisProperties.getPassword());
             sentinelManager.setDatabase(redisProperties.getDatabase());
 
             return sentinelManager;


### PR DESCRIPTION
当使用redis的sentinel模式时，如果设置了redis的密码但未设置sentinel密码，会造成失败。NOAUTH Authentication required.