### PR TITLE
将字段名长度从32改为64

### DIFF
--- a/jeecg-boot/db/jeecgboot-mysql-5.7.sql
+++ b/jeecg-boot/db/jeecgboot-mysql-5.7.sql
@@ -2110,6 +2110,8 @@ CREATE TABLE `onl_cgform_field`  (
   INDEX `idx_ocf_cgform_head_id`(`cgform_head_id`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8 COLLATE = utf8_general_ci ROW_FORMAT = DYNAMIC;
 
+-- 修改字段名长度
+ALTER TABLE onl_cgform_field MODIFY db_field_name VARCHAR(64);
 -- ----------------------------
 -- Records of onl_cgform_field
 -- ----------------------------
@@ -2850,7 +2852,6 @@ INSERT INTO `onl_cgform_field` VALUES ('ff49b468e54e137032f7e4d976b83b5a', '4028
 INSERT INTO `onl_cgform_field` VALUES ('ff601f75d0e7ced226748eb8fba2c896', '402860816bff91c0016bff91d8830007', 'relation', '关系', 'relation', 0, 1, 1, 'string', 100, 0, '', '', '', '', 'text', '', 120, NULL, '0', '', '', 0, 1, 1, 0, 'group', '', '', 4, 'admin', '2019-07-19 18:04:41', '2019-07-17 18:54:37', 'admin', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO `onl_cgform_field` VALUES ('ffacafee9fa46eb297ca3252f95acef9', '402860816bff91c0016bffa220a9000b', 'school', '毕业学校', 'school', 0, 1, 1, 'string', 100, 0, '', '', '', '', 'text', '', 120, NULL, '0', '', '', 0, 1, 1, 0, 'group', '', '', 9, 'admin', '2019-07-22 16:15:32', '2019-07-17 19:12:24', 'admin', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 INSERT INTO `onl_cgform_field` VALUES ('ffcbf379fffabbd13aa2c22ce565ec12', '79091e8277c744158530321513119c68', 'update_by', '更新人', NULL, 0, 1, 1, 'string', 50, 0, '', '', '', '', 'text', '', 120, NULL, '0', '', '', 0, 0, 0, 0, 'single', '', '', 4, 'admin', '2019-05-11 15:29:47', '2019-05-11 15:27:17', 'admin', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
 -- ----------------------------
 -- Table structure for onl_cgform_head
 -- ----------------------------

--- a/jeecg-boot/db/jeecgboot-mysql-5.7.sql
+++ b/jeecg-boot/db/jeecgboot-mysql-5.7.sql
@@ -2112,6 +2112,7 @@ CREATE TABLE `onl_cgform_field`  (
 
 -- 修改字段名长度
 ALTER TABLE onl_cgform_field MODIFY db_field_name VARCHAR(64);
+ALTER TABLE db_field_name_old MODIFY db_field_name VARCHAR(64);
 -- ----------------------------
 -- Records of onl_cgform_field
 -- ----------------------------


### PR DESCRIPTION
在特殊情况下，字段名可能会超出32位，可以将该字段长度从32改为64