### PR TITLE
修复flyway自动升级失败

### DIFF
--- a/jeecg-boot/jeecg-module-system/jeecg-system-start/src/main/java/org/jeecg/config/flyway/FlywayConfig.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-start/src/main/java/org/jeecg/config/flyway/FlywayConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
+import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public class FlywayConfig {
      */
     @Value("${spring.flyway.enabled:false}")
     private Boolean enabled;
-    
+
     /**
      * 编码格式，默认UTF-8
      */
@@ -95,13 +96,13 @@ public class FlywayConfig {
      */
     @Value("${spring.flyway.clean-disabled:true}")
     private Boolean cleanDisabled;
-    
-    @Bean
+
+    @PostConstruct
     public void migrate() {
         if(!enabled){
             return;
         }
-        
+
         DynamicRoutingDataSource ds = (DynamicRoutingDataSource) dataSource;
         Map<String, DataSource> dataSources = ds.getDataSources();
         dataSources.forEach((k, v) -> {


### PR DESCRIPTION
3.7.0升级到3.7.2，由于flyway加载顺序晚于积木报表v1.9.1中的jimuReportAutoServiceImpl加载，导致报错,jimu_report_export_job表不存在