### PR TITLE
upgrade shiro to 2.0.4

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/pom.xml
+++ b/jeecg-boot/jeecg-boot-base-core/pom.xml
@@ -196,6 +196,7 @@
 		<dependency>
 			<groupId>org.apache.shiro</groupId>
 			<artifactId>shiro-spring-boot-starter</artifactId>
+			<classifier>jakarta</classifier>
 			<version>${shiro.version}</version>
 			<exclusions>
 				<exclusion>

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/encryption/AesEncryptUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/encryption/AesEncryptUtil.java
@@ -1,6 +1,6 @@
 package org.jeecg.common.util.encryption;
 
-import org.apache.shiro.codec.Base64;
+import org.apache.shiro.lang.codec.Base64;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;

--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -65,7 +65,7 @@
 		<aliyun-java-sdk-dysmsapi.version>2.1.0</aliyun-java-sdk-dysmsapi.version>
 		<aliyun.oss.version>3.17.3</aliyun.oss.version>
 		<!-- shiro -->
-		<shiro.version>1.12.0</shiro.version>
+		<shiro.version>2.0.4</shiro.version>
 		<java-jwt.version>3.11.0</java-jwt.version>
 		<shiro-redis.version>3.2.2</shiro-redis.version>
 		<codegenerate.version>1.4.9</codegenerate.version>


### PR DESCRIPTION
upgrade shiro to 2.0.4

修改 Shiro 版本为 2.0.4， shiro-spring-boot-starter 使用基于jakarta的依赖