### PR TITLE
feat: 升级 shiro 到 2.0.4 版本，解决 ShiroRequestMappingConfig 获取 RequestMappingHandlerMapping Bean 冲突

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/pom.xml
+++ b/jeecg-boot/jeecg-boot-base-core/pom.xml
@@ -204,6 +204,7 @@
 		<dependency>
 			<groupId>org.apache.shiro</groupId>
 			<artifactId>shiro-spring-boot-starter</artifactId>
+			<classifier>jakarta</classifier>
 			<version>${shiro.version}</version>
 			<exclusions>
 				<exclusion>

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/encryption/AesEncryptUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/encryption/AesEncryptUtil.java
@@ -1,6 +1,6 @@
 package org.jeecg.common.util.encryption;
 
-import org.apache.shiro.codec.Base64;
+import org.apache.shiro.lang.codec.Base64;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java
@@ -1,5 +1,8 @@
 package org.jeecg.config.shiro;
 
+import jakarta.annotation.Resource;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.shiro.mgt.DefaultSessionStorageEvaluator;
@@ -17,25 +20,20 @@ import org.jeecg.config.shiro.filters.CustomShiroFilterFactoryBean;
 import org.jeecg.config.shiro.filters.JwtFilter;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.*;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.env.Environment;
-import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.web.filter.DelegatingFilterProxy;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 
-import jakarta.annotation.Resource;
-import jakarta.servlet.Filter;
-import jakarta.servlet.DispatcherType;
-import java.lang.reflect.Method;
 import java.util.*;
 
 /**
@@ -348,6 +346,17 @@ public class ShiroConfig {
             manager = redisManager;
         }
         return manager;
+    }
+
+    /**
+     * 解决 ShiroRequestMappingConfig 获取 requestMappingHandlerMapping Bean 冲突
+     * spring-boot-autoconfigure:3.4.5 和 spring-boot-actuator-autoconfigure:3.4.5
+     */
+    @Primary
+    @Bean
+    public RequestMappingHandlerMapping shiroRequestMappingHandlerMapping(
+            @Qualifier("requestMappingHandlerMapping") RequestMappingHandlerMapping handlerMapping) {
+        return handlerMapping;
     }
 
     private List<String> rebuildUrl(String[] bases, String[] uris) {

--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -67,7 +67,7 @@
 		<aliyun-java-sdk-dysmsapi.version>2.1.0</aliyun-java-sdk-dysmsapi.version>
 		<aliyun.oss.version>3.17.3</aliyun.oss.version>
 		<!-- shiro -->
-		<shiro.version>1.13.0</shiro.version>
+		<shiro.version>2.0.4</shiro.version>
 		<shiro-redis.version>3.2.3</shiro-redis.version>
 		<java-jwt.version>3.11.0</java-jwt.version>
 		<codegenerate.version>1.4.9</codegenerate.version>


### PR DESCRIPTION
feat: 升级 shiro 到 2.0.4 版本，解决Shiro获取 requestMappingHandlerMapping 时 spring-boot-autoconfigure:3.4.5 和 spring-boot-actuator-autoconfigure:3.4.5 Bean 依赖冲突，