### PR TITLE
logging(level): 设置 PostProcessorRegistrationDelegate 日志级别为 error

### DIFF
--- a/jeecg-boot/jeecg-module-system/jeecg-system-start/src/main/resources/application-dev.yml
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-start/src/main/resources/application-dev.yml
@@ -306,6 +306,7 @@ logging:
   level:
     org.flywaydb: debug
     org.jeecg.modules.system.mapper: info
+    org.springframework.context.support.PostProcessorRegistrationDelegate: error
 knife4j:
   #开启增强配置
   enable: true


### PR DESCRIPTION
- 在 application-dev.yml 文件中添加了 org.springframework.context.support.PostProcessorRegistrationDelegate 的日志级别配置
- 此修改旨在减少不必要的日志输出，提高日志的可读性和性能