### PR TITLE
解决TableAction中自定义图标颜色不起作用的问题

### DIFF
--- a/jeecgboot-vue3/src/components/Table/src/components/TableAction.vue
+++ b/jeecgboot-vue3/src/components/Table/src/components/TableAction.vue
@@ -7,12 +7,12 @@
       <template v-else>
         <Tooltip v-if="action.tooltip" v-bind="getTooltip(action.tooltip)">
           <PopConfirmButton v-bind="action">
-            <Icon :icon="action.icon" :class="{ 'mr-1': !!action.label }" v-if="action.icon" />
+            <Icon :icon="action.icon" :class="{ 'mr-1': !!action.label }" v-if="action.icon" :color="action.iconColor"/>
             <template v-if="action.label">{{ action.label }}</template>
           </PopConfirmButton>
         </Tooltip>
         <PopConfirmButton v-else v-bind="action">
-          <Icon :icon="action.icon" :class="{ 'mr-1': !!action.label }" v-if="action.icon" />
+          <Icon :icon="action.icon" :class="{ 'mr-1': !!action.label }" v-if="action.icon" :color="action.iconColor"/>
           <template v-if="action.label">{{ action.label }}</template>
         </PopConfirmButton>
       </template>


### PR DESCRIPTION
项目中需要在BasicTable的操作栏中添加星星收藏按钮，配置iconColor发现不起作用。于是修改源码中的代码，实现效果。