### PR TITLE
fix(xxljob): 修复因 factoryBeanObjectType 导致的启动失败

### DIFF
--- a/jeecg-boot/jeecg-server-cloud/jeecg-visual/jeecg-cloud-xxljob/pom.xml
+++ b/jeecg-boot/jeecg-server-cloud/jeecg-visual/jeecg-cloud-xxljob/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.mybatis.spring.boot</groupId>
             <artifactId>mybatis-spring-boot-starter</artifactId>
-            <version>2.3.2</version>
+            <version>3.0.3</version>
         </dependency>
         <!-- mysql -->
         <dependency>


### PR DESCRIPTION
# Pull Request 提交说明

## `fix(xxljob): 解决SpringBoot启动时factoryBeanObjectType类型报错`

## 问题描述
在SpringBoot 3启动时出现以下错误：
java.lang.IllegalArgumentException:Invalid value type for attribute 'factoryBeanObjectType': java.lang.String

## 问题原因
1. **Spring 6.1+新规范**  
   强制要求`factoryBeanObjectType`必须为`Class`或`ResolvableType`
2. **旧版组件问题**  
   MyBatis-Spring (<3.0.3)等组件使用了String类型设置该属性

## 修复方案
### 依赖升级
```xml
<!-- pom.xml修改 -->
        <dependency>
            <groupId>org.mybatis.spring.boot</groupId>
            <artifactId>mybatis-spring-boot-starter</artifactId>
            <version>3.0.3</version>
        </dependency>
```
## 兼容性检查清单

- [x] 升级MyBatis-Spring到3.0.3+  
- [x] 检查Spring Cloud版本兼容性  
- [ ] 验证自定义FactoryBean实现  
- [ ] 检查其他第三方starter依赖  

## 测试验证

| 测试场景       | 测试结果 | 详细说明                 |
|----------------|----------|--------------------------|
| 应用冷启动     | ✅ PASS   | 无类型校验相关报错       |
| 任务调度触发   | ✅ PASS   | XXLJob任务正常触发执行   |
| 数据库访问     | ✅ PASS   | MyBatis映射查询正常      |
| AOP切面        | ✅ PASS   | 事务管理等切面正常生效  |

## 相关链接

- [Spring Framework原始Issue #31247](https://github.com/spring-projects/spring-framework/issues/31247)  
- [Spring Boot 3.2兼容性指南](https://spring.io/projects/spring-boot#support)  
