### PR TITLE
Update renderUtils.ts 修复字典渲染renderTag使用tag渲染没使用字典配置颜色的问题

### DIFF
--- a/jeecgboot-vue3/src/utils/common/renderUtils.ts
+++ b/jeecgboot-vue3/src/utils/common/renderUtils.ts
@@ -45,15 +45,17 @@ const render = {
    */
   renderDict: (v, code, renderTag = false) => {
     let text = '';
+    let color = '';
     let array = getDictItemsByCode(code) || [];
     let obj = array.filter((item) => {
       return item.value == v;
     });
     if (obj.length > 0) {
       text = obj[0].text;
+      color = obj[0].color;
     }
     //【jeecgboot-vue3/issues/903】render.renderDict使用tag渲染报警告问题 #903
-    return isEmpty(text) || !renderTag ? h('span', text) : h(Tag, () => text);
+    return isEmpty(text) || !renderTag ? h('span', text) : h(Tag,{ color }, () => text);
   },
   /**
    * 渲染图片


### PR DESCRIPTION
在renderDict方法中增加颜色属性传递，使得tag 根据字典配置的颜色渲染
render.renderDict(text, 'bpm_status',true)
<img width="150" height="201" alt="image" src="https://github.com/user-attachments/assets/585741dd-8f81-41f4-a14b-54202ec1f230" />
