### PR TITLE
docs: fix spelling typos

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-module-demo/src/main/resources/static/bigscreen/template1/js/echarts-wordcloud.js
+++ b/jeecg-boot/jeecg-boot-module/jeecg-module-demo/src/main/resources/static/bigscreen/template1/js/echarts-wordcloud.js
@@ -8930,7 +8930,7 @@ function enableClassExtend(RootClass, mandatoryMethods) {
 // class A has method f,
 // class B inherits class A, overrides method f, f call superApply('f'),
 // class C inherits class B, do not overrides method f,
-// then when method of class C is called, dead loop occured.
+// then when method of class C is called, dead loop occurred.
 
 
 function superCall(context, methodName) {

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/static/generic/web/debugger.js
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/static/generic/web/debugger.js
@@ -582,7 +582,7 @@ var PDFBug = (function PDFBugClosure() {
         } else {
           panel.textContent = tool.name + ' is disabled. To enable add ' +
                               ' "' + tool.id + '" to the pdfBug parameter ' +
-                              'and refresh (seperate multiple by commas).';
+                              'and refresh (separate multiple by commas).';
         }
         buttons.push(panelButton);
       }

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/static/generic/web/l10n.js
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/static/generic/web/l10n.js
@@ -149,7 +149,7 @@ document.webL10n = (function(window, document, undefined) {
    *    triggered when the l10n resource has been successully parsed.
    *
    * @param {Function} failureCallback
-   *    triggered when the an error has occured.
+   *    triggered when the an error has occurred.
    *
    * @return {void}
    *    uses the following global variables: gL10nData, gTextData, gTextProp.


### PR DESCRIPTION
## Summary

Fixed 3 spelling typos found in the codebase.

### Files changed
- `jeecg-boot/jeecg-boot-module/jeecg-module-demo/src/main/resources/static/bigscreen/template1/js/echarts-wordcloud.js`
- `jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/static/generic/web/debugger.js`
- `jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/static/generic/web/l10n.js`
