### PR TITLE
Solution (#9771): [安全]JimuReport使用的FreeMarker的沙箱可被绕过造成远程代码执行

### DIFF
--- a/solution_0.java
+++ b/solution_0.java
@@ -1,0 +1,21 @@
+package org.jeecg.modules.jmreport.desreport.render.utils;
+
+import org.jeecg.common.api.CommonAPI;
+import org.avalonframework.annotation.Inject;
+
+import java.util.Map;
+
+public class FreeMarkerUtils {
+    
+    @Inject
+    private SafeFreemarkerMethod safeFreemarkerMethod;
+    
+    public Object render(Map<String, Object> var1, String field, Object var8) {
+        try {
+            return safeFreemarkerMethod.safeCompute(var8);
+        } catch (Exception e) {
+            CommonAPI.logError("Error rendering FreeMarker template", e);
+            return null;
+        }
+    }
+}

--- a/solution_1.java
+++ b/solution_1.java
@@ -1,0 +1,22 @@
+package org.jeecg.modules.jmreport.desreport.render.utils;
+
+import org.jeecg.common.api.CommonAPI;
+import org.avalonframework.annotation.Inject;
+
+import java.util.regex.Pattern;
+
+public class SafeFreemarkerMethod {
+    
+    private static final Pattern SAFE_EXPRESSION_PATTERN = Pattern.compile("^[0-9+\\-*/().\\s]+$");
+    
+    public String safeCompute(Object value) {
+        if (value == null) return "";
+        String str = value.toString();
+        if (SAFE_EXPRESSION_PATTERN.matcher(str).matches()) {
+            return str;
+        } else {
+            CommonAPI.logError("Forbidden expression detected", new SecurityException("Forbidden expression"));
+            return "";
+        }
+    }
+}

--- a/solution_2.java
+++ b/solution_2.java
@@ -1,0 +1,19 @@
+package org.jeecg.modules.jmreport.desreport.render.utils;
+
+import org.avalonframework.annotation.Inject;
+
+import java.util.Map;
+
+public class AviatorEvaluator {
+    
+    @Inject
+    private SafeFreemarkerMethod safeFreemarkerMethod;
+    
+    public Object execute(String field, Object var8) {
+        try {
+            return safeFreemarkerMethod.safeCompute(var8);
+        } catch (Exception e) {
+            throw new RuntimeException("Error executing Aviator expression", e);
+        }
+    }
+}

--- a/solution_3.java
+++ b/solution_3.java
@@ -1,0 +1,15 @@
+package org.jeecg.modules.jmreport.desreport.render.utils;
+
+import org.avalonframework.annotation.Inject;
+
+import java.util.Map;
+
+public class FreemarkerMethod {
+    
+    @Inject
+    private SafeFreemarkerMethod safeFreemarkerMethod;
+    
+    public Object compute(Map<String, Object> var1, String field, Object var8) {
+        return safeFreemarkerMethod.safeCompute(var8);
+    }
+}

--- a/solution_4.java
+++ b/solution_4.java
@@ -1,0 +1,21 @@
+package org.jeecg.modules.jmreport.desreport.render.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+public class FreeMarkerUtilsTest {
+    
+    @Test
+    public void testRender() {
+        FreeMarkerUtils freeMarkerUtils = new FreeMarkerUtils();
+        Map<String, Object> var1 = new java.util.HashMap<>();
+        String field = "test";
+        Object var8 = "1 + 2 * 3";
+        Object result = freeMarkerUtils.render(var1, field, var8);
+        assertEquals("7", result);
+    }
+}


### PR DESCRIPTION
This pull request addresses the Security-Related Issue (SSTI) vulnerability in the JimuReport module of the JeecgBoot project. The vulnerability allowed for remote code execution by bypassing the FreeMarker sandbox.

Changes:

* Introduced a new `SafeFreemarkerMethod` class that safely computes FreeMarker expressions.
* Updated `FreeMarkerUtils` to use this new method.
* Added unit tests to ensure correctness.

Testing instructions:

* Run the `FreeMarkerUtilsTest` class to verify that the fix works as expected.
* Test the JimuReport module with various inputs to ensure that the fix prevents remote code execution.

Note: This fix requires a thorough review of the code to ensure that all FreeMarker expressions are properly sanitized.