### PR TITLE
fix: harden dict APIs for issue #9840

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/SqlInjectionUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/SqlInjectionUtil.java
@@ -91,6 +91,23 @@ public class SqlInjectionUtil {
 	 */
 	private final static Pattern SQL_ANNOTATION = Pattern.compile("/\\*[\\s\\S]*\\*/");
 	private final static  String SQL_ANNOTATION2 = "--";
+
+	/**
+	 * 【issue/9840】dict filterSql 白名单：仅允许简单比较 / IN 列表，以及 AND/OR 连接。
+	 * Unicode-unaware；AND/OR/IN 大小写不敏感。
+	 */
+	private static final String DICT_FILTER_IDENT = "[A-Za-z_][A-Za-z0-9_.]*";
+	private static final String DICT_FILTER_NUMBER = "[0-9]+(?:\\.[0-9]+)?";
+	private static final String DICT_FILTER_STRING = "'[^']*'";
+	private static final String DICT_FILTER_LITERAL = "(?:" + DICT_FILTER_NUMBER + "|" + DICT_FILTER_STRING + ")";
+	private static final String DICT_FILTER_OP = "(?:!=|<>|>=|<=|=|>|<)";
+	private static final String DICT_FILTER_COMPARISON = DICT_FILTER_IDENT + "\\s*" + DICT_FILTER_OP + "\\s*" + DICT_FILTER_LITERAL;
+	private static final String DICT_FILTER_IN = DICT_FILTER_IDENT + "\\s+IN\\s*\\(\\s*" + DICT_FILTER_LITERAL
+			+ "(?:\\s*,\\s*" + DICT_FILTER_LITERAL + ")*\\s*\\)";
+	private static final String DICT_FILTER_PREDICATE = "(?:" + DICT_FILTER_COMPARISON + "|" + DICT_FILTER_IN + ")";
+	private static final Pattern DICT_FILTER_SQL_WHITELIST = Pattern.compile(
+			"^\\s*" + DICT_FILTER_PREDICATE + "(?:\\s+(?:AND|OR)\\s+" + DICT_FILTER_PREDICATE + ")*\\s*$",
+			Pattern.CASE_INSENSITIVE);
 	
 	/**
 	 * sql注入提示语
@@ -272,10 +289,42 @@ public class SqlInjectionUtil {
 	 * @return
 	 */
 	public static void specialFilterContentForDictSql(String value) {
-		String[] xssArr = specialDictSqlXssStr.split("\\|");
 		if (value == null || "".equals(value)) {
 			return;
 		}
+		//update-begin---author:jeecg ---date:2026-08-24  for：【issue/9840】dict filterSql 白名单，黑名单作为纵深防御-----------
+		assertDictFilterSqlWhitelist(value);
+		applySpecialDictSqlBlacklist(value);
+		//update-end-----author:jeecg ---date:2026-08-24  for：【issue/9840】dict filterSql 白名单，黑名单作为纵深防御-----------
+	}
+
+	/**
+	 * 仅关键词黑名单（无白名单）。用于表名、dictCode、以及服务端内部拼接的 LIKE/ORDER BY 片段。
+	 * 用户传入的 filterSql / condition 请走 {@link #specialFilterContentForDictSql(String)}。
+	 */
+	public static void filterDictSqlKeywordBlacklist(String value) {
+		if (value == null || "".equals(value)) {
+			return;
+		}
+		applySpecialDictSqlBlacklist(value);
+	}
+
+	/**
+	 * 【issue/9840】仅允许简单比较表达式与 IN 列表。空串视为无过滤条件（与历史行为一致）。
+	 */
+	private static void assertDictFilterSqlWhitelist(String value) {
+		String trimmed = value.trim();
+		if (trimmed.isEmpty()) {
+			return;
+		}
+		if (!DICT_FILTER_SQL_WHITELIST.matcher(trimmed).matches()) {
+			log.error(SqlInjectionUtil.SQL_INJECTION_TIP_VARIABLE, value);
+			throw new JeecgSqlInjectionException(SqlInjectionUtil.SQL_INJECTION_TIP + value);
+		}
+	}
+
+	private static void applySpecialDictSqlBlacklist(String value) {
+		String[] xssArr = specialDictSqlXssStr.split("\\|");
 		// 一、校验sql注释 不允许有sql注释
 		checkSqlAnnotation(value);
 		value = value.toLowerCase().trim();

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java
@@ -57,6 +57,51 @@ public class ShiroConfig {
     private DataRedisProperties redisProperties;
     //update-end---author:scott ---date:2026-07-07  for：【Spring Boot 4.0 升级】RedisProperties 改名为 DataRedisProperties，包路径变更-----------
     
+
+    /**
+     * 【issue/9840】字典/表字典接口必须强制 JWT，且必须登记在静态资源后缀 anon 规则之前，
+     * 避免请求路径形如静态资源时命中匿名放行。
+     */
+    static final String[] DICT_API_JWT_PATHS = new String[] {
+            "/sys/dict/getDictItems/**",
+            "/sys/dict/loadDict/**",
+            "/sys/dict/loadDictItem/**",
+            "/sys/dict/loadDictOrderByValue/**",
+            "/sys/dict/loadTreeData",
+            "/sys/dict/queryTableData",
+            "/sys/api/queryFilterTableDictInfo",
+            "/sys/api/queryTableDictItemsByCode",
+            "/sys/api/loadDictItemByKeyword"
+    };
+
+    /**
+     * 先登记字典 JWT，再登记静态资源 anon。LinkedHashMap 插入顺序即 Shiro 匹配顺序。
+     * 包可见，供单测校验顺序，无需启动 Spring/Redis。
+     */
+    static void putDictJwtThenStaticResourceAnon(Map<String, String> filterChainDefinitionMap) {
+        for (String path : DICT_API_JWT_PATHS) {
+            filterChainDefinitionMap.put(path, "jwt");
+        }
+        // 配置不会被拦截的链接 顺序判断
+        filterChainDefinitionMap.put("/", "anon");
+        filterChainDefinitionMap.put("/doc.html", "anon");
+        filterChainDefinitionMap.put("/**/*.js", "anon");
+        filterChainDefinitionMap.put("/**/*.css", "anon");
+        filterChainDefinitionMap.put("/**/*.html", "anon");
+        filterChainDefinitionMap.put("/**/*.svg", "anon");
+        filterChainDefinitionMap.put("/**/*.pdf", "anon");
+        filterChainDefinitionMap.put("/**/*.jpg", "anon");
+        filterChainDefinitionMap.put("/**/*.png", "anon");
+        filterChainDefinitionMap.put("/**/*.gif", "anon");
+        filterChainDefinitionMap.put("/**/*.ico", "anon");
+        filterChainDefinitionMap.put("/**/*.ttf", "anon");
+        filterChainDefinitionMap.put("/**/*.woff", "anon");
+        filterChainDefinitionMap.put("/**/*.woff2", "anon");
+
+        filterChainDefinitionMap.put("/**/*.glb", "anon");
+        filterChainDefinitionMap.put("/**/*.wasm", "anon");
+    }
+
     /**
      * Filter Chain定义说明
      *
@@ -111,24 +156,8 @@ public class ShiroConfig {
         filterChainDefinitionMap.put("/sys/checkAuth", "anon"); //授权接口排除
         filterChainDefinitionMap.put("/openapi/call/**", "anon"); // 开放平台接口排除
 
-        // 代码逻辑说明: 排除静态资源后缀
-        filterChainDefinitionMap.put("/", "anon");
-        filterChainDefinitionMap.put("/doc.html", "anon");
-        filterChainDefinitionMap.put("/**/*.js", "anon");
-        filterChainDefinitionMap.put("/**/*.css", "anon");
-        filterChainDefinitionMap.put("/**/*.html", "anon");
-        filterChainDefinitionMap.put("/**/*.svg", "anon");
-        filterChainDefinitionMap.put("/**/*.pdf", "anon");
-        filterChainDefinitionMap.put("/**/*.jpg", "anon");
-        filterChainDefinitionMap.put("/**/*.png", "anon");
-        filterChainDefinitionMap.put("/**/*.gif", "anon");
-        filterChainDefinitionMap.put("/**/*.ico", "anon");
-        filterChainDefinitionMap.put("/**/*.ttf", "anon");
-        filterChainDefinitionMap.put("/**/*.woff", "anon");
-        filterChainDefinitionMap.put("/**/*.woff2", "anon");
-
-        filterChainDefinitionMap.put("/**/*.glb", "anon");
-        filterChainDefinitionMap.put("/**/*.wasm", "anon");
+        // 代码逻辑说明: 【issue/9840】字典 JWT 必须在静态资源匿名规则之前
+        putDictJwtThenStaticResourceAnon(filterChainDefinitionMap);
 
         filterChainDefinitionMap.put("/druid/**", "anon");
         filterChainDefinitionMap.put("/swagger-ui.html", "anon");

--- a/jeecg-boot/jeecg-boot-base-core/src/test/java/org/jeecg/config/shiro/Issue9840_ShiroDictJwtFilterOrderTest.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/test/java/org/jeecg/config/shiro/Issue9840_ShiroDictJwtFilterOrderTest.java
@@ -1,0 +1,71 @@
+package org.jeecg.config.shiro;
+
+import org.jeecg.test.security.PrintTestResultExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 【issue/9840】字典接口 JWT 规则必须出现在静态后缀 anon 之前；catch-all jwt 仍保留。
+ */
+@ExtendWith(PrintTestResultExtension.class)
+public class Issue9840_ShiroDictJwtFilterOrderTest {
+
+    @Test
+    @DisplayName("getDictItems 为 jwt 且排在 /**/*.js 之前")
+    void dictJwtBeforeStaticJsAnon() {
+        Map<String, String> chain = new LinkedHashMap<>();
+        ShiroConfig.putDictJwtThenStaticResourceAnon(chain);
+
+        assertEquals("jwt", chain.get("/sys/dict/getDictItems/**"));
+        List<String> keys = new ArrayList<>(chain.keySet());
+        int dictIdx = keys.indexOf("/sys/dict/getDictItems/**");
+        int jsIdx = keys.indexOf("/**/*.js");
+        assertTrue(dictIdx >= 0, "missing dict jwt path");
+        assertTrue(jsIdx >= 0, "missing static js anon rule");
+        assertTrue(dictIdx < jsIdx, "dict jwt must be registered before /**/*.js");
+    }
+
+    @Test
+    @DisplayName("全部字典 JWT 路径均为 jwt 且均在 /**/*.js 之前")
+    void allDictJwtPathsBeforeStaticJs() {
+        Map<String, String> chain = new LinkedHashMap<>();
+        ShiroConfig.putDictJwtThenStaticResourceAnon(chain);
+        List<String> keys = new ArrayList<>(chain.keySet());
+        int jsIdx = keys.indexOf("/**/*.js");
+        assertTrue(jsIdx >= 0);
+        for (String path : ShiroConfig.DICT_API_JWT_PATHS) {
+            assertEquals("jwt", chain.get(path), path);
+            int idx = keys.indexOf(path);
+            assertTrue(idx >= 0 && idx < jsIdx, path + " must appear before /**/*.js");
+        }
+        assertEquals("anon", chain.get("/**/*.js"));
+    }
+
+    @Test
+    @DisplayName("shiroFilter 源码仍在链尾登记 /** jwt")
+    void catchAllJwtStillPresentInSource() throws Exception {
+        Path src = Paths.get("src/main/java/org/jeecg/config/shiro/ShiroConfig.java");
+        if (!Files.isRegularFile(src)) {
+            src = Paths.get("jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/shiro/ShiroConfig.java");
+        }
+        assertTrue(Files.isRegularFile(src), "ShiroConfig.java not found: " + src.toAbsolutePath());
+        String content = Files.readString(src, StandardCharsets.UTF_8);
+        assertTrue(content.contains("put(\"/**\", \"jwt\")"), "catch-all jwt must remain");
+        int dictHelper = content.indexOf("putDictJwtThenStaticResourceAnon");
+        int catchAll = content.lastIndexOf("put(\"/**\", \"jwt\")");
+        assertTrue(dictHelper >= 0 && catchAll > dictHelper, "catch-all jwt must stay after dict jwt registration");
+    }
+}

--- a/jeecg-boot/jeecg-boot-base-core/src/test/java/org/jeecg/test/security/Issue9677_SqlInjectionNewlineBypassTest.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/test/java/org/jeecg/test/security/Issue9677_SqlInjectionNewlineBypassTest.java
@@ -193,9 +193,10 @@ public class Issue9677_SqlInjectionNewlineBypassTest {
         }
 
         @Test
-        @DisplayName("字典条件中含like的合法查询通过")
-        void likePasses() {
-            assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("name like '%张%'"));
+        @DisplayName("字典条件中的 like 由 issue/9840 白名单拒绝")
+        void likeRejectedByDictFilterWhitelist() {
+            assertThrows(JeecgSqlInjectionException.class,
+                    () -> SqlInjectionUtil.specialFilterContentForDictSql("name like '%张%'"));
         }
 
         @Test

--- a/jeecg-boot/jeecg-boot-base-core/src/test/java/org/jeecg/test/security/Issue9840_DictFilterSqlWhitelistTest.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/test/java/org/jeecg/test/security/Issue9840_DictFilterSqlWhitelistTest.java
@@ -1,0 +1,85 @@
+package org.jeecg.test.security;
+
+import org.jeecg.common.exception.JeecgSqlInjectionException;
+import org.jeecg.common.util.SqlInjectionUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * 【issue/9840】dict filterSql 白名单：仅接受简单比较表达式。
+ */
+@ExtendWith(PrintTestResultExtension.class)
+public class Issue9840_DictFilterSqlWhitelistTest {
+
+    @Test
+    @DisplayName("合法 filterSql del_flag=0 通过")
+    void acceptsDelFlagEqualsZero() {
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("del_flag=0"));
+    }
+
+    @Test
+    @DisplayName("合法 filterSql status='1' 通过")
+    void acceptsQuotedStatus() {
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("status='1'"));
+    }
+
+    @Test
+    @DisplayName("合法 filterSql del_flag=0 and status='1' 通过")
+    void acceptsAndChain() {
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("del_flag=0 and status='1'"));
+    }
+
+    @Test
+    @DisplayName("空白与换行分隔的简单比较仍通过")
+    void acceptsWhitespaceBetweenTokens() {
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("del_flag=0\nand\nstatus='1'"));
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("status IN ('1','2')"));
+    }
+
+    @Test
+    @DisplayName("空/null 视为无过滤条件")
+    void emptyIsNoOp() {
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql(""));
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql(null));
+        assertDoesNotThrow(() -> SqlInjectionUtil.specialFilterContentForDictSql("   "));
+    }
+
+    @Test
+    @DisplayName("含分号的语法被拒绝")
+    void rejectsSemicolon() {
+        assertThrows(JeecgSqlInjectionException.class,
+                () -> SqlInjectionUtil.specialFilterContentForDictSql("id=1;"));
+    }
+
+    @Test
+    @DisplayName("含 SQL 行注释标记被拒绝")
+    void rejectsLineCommentMarker() {
+        assertThrows(RuntimeException.class,
+                () -> SqlInjectionUtil.specialFilterContentForDictSql("id=1--"));
+    }
+
+    @Test
+    @DisplayName("含块注释标记被拒绝")
+    void rejectsBlockCommentMarker() {
+        assertThrows(RuntimeException.class,
+                () -> SqlInjectionUtil.specialFilterContentForDictSql("id=1 /*"));
+    }
+
+    @Test
+    @DisplayName("函数调用形态 sleep( 被拒绝")
+    void rejectsParenCallPattern() {
+        assertThrows(JeecgSqlInjectionException.class,
+                () -> SqlInjectionUtil.specialFilterContentForDictSql("id=sleep("));
+    }
+
+    @Test
+    @DisplayName("select 作为多余 token 被拒绝")
+    void rejectsSelectAsExtraToken() {
+        assertThrows(JeecgSqlInjectionException.class,
+                () -> SqlInjectionUtil.specialFilterContentForDictSql("id=1 select"));
+    }
+}

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/service/impl/SysDictServiceImpl.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/service/impl/SysDictServiceImpl.java
@@ -314,7 +314,7 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 		log.debug("无缓存dictTableList的时候调用这里！");
 
 		// 1.SQL注入校验（只限制非法串改数据库）
-		SqlInjectionUtil.specialFilterContentForDictSql(table);
+		SqlInjectionUtil.filterDictSqlKeywordBlacklist(table);
 		SqlInjectionUtil.filterContentMulti(text, code);
 		SqlInjectionUtil.specialFilterContentForDictSql(filterSql);
 		
@@ -582,6 +582,11 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 	 * @return
 	 */
 	private String getFilterSql(String tableSql, String text, String code, String condition, String keyword){
+		//update-begin---author:jeecg ---date:2026-08-24  for：【issue/9840】用户传入的 condition 走白名单-----------
+		if (oConvertUtils.isNotEmpty(condition)) {
+			SqlInjectionUtil.specialFilterContentForDictSql(condition);
+		}
+		//update-end-----author:jeecg ---date:2026-08-24  for：【issue/9840】用户传入的 condition 走白名单-----------
 		String filterSql = "";
 		String keywordSql = null;
 		String sqlWhere = "where ";
@@ -642,8 +647,8 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 		// 1.1 返回条件SQL（去掉开头的 where ）
 		final String wherePrefix = "(?i)where "; // (?i) 表示不区分大小写
 		String filterSqlString = filterSql.trim().replaceAll(wherePrefix, "");
-		// 1.2 条件SQL进行漏洞 check
-		SqlInjectionUtil.specialFilterContentForDictSql(filterSqlString);
+		// 1.2 条件SQL进行漏洞 check（内部拼接含 LIKE/ORDER BY，仅黑名单；用户 condition 已在方法入口白名单校验）
+		SqlInjectionUtil.filterDictSqlKeywordBlacklist(filterSqlString);
 		// 1.3 判断如何返回条件是 order by开头则前面拼上 1=1
 		if (oConvertUtils.isNotEmpty(filterSqlString) && filterSqlString.trim().toUpperCase().startsWith("ORDER")) {
 			filterSqlString = " 1=1 " + filterSqlString;
@@ -821,8 +826,8 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 			return null;
 		}
 		
-		// 2.字典SQL注入风险check
-		SqlInjectionUtil.specialFilterContentForDictSql(dictCode);
+		// 2.字典SQL注入风险check（dictCode 为 table,text,code[,condition]，非单一 filterSql）
+		SqlInjectionUtil.filterDictSqlKeywordBlacklist(dictCode);
 
 		if (dictCode.contains(SymbolConstant.COMMA)) {
 			// 代码逻辑说明: 下拉搜索不支持表名后加查询条件
@@ -885,7 +890,7 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 		sysBaseAPI.dictTableWhiteListCheckByDict(tableName, allFieldList.toArray(new String[0]));
 
 		// 1.2 SQL 注入基础检查
-		SqlInjectionUtil.specialFilterContentForDictSql(tableName);
+		SqlInjectionUtil.filterDictSqlKeywordBlacklist(tableName);
 
 		// ---------- 2. 转义表名与字段 ----------
 		String safeTable = SqlInjectionUtil.getSqlInjectTableName(tableName.trim());
@@ -933,7 +938,8 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 
 		String filterSql = conditionParts.isEmpty() ? "" : String.join(" and ", conditionParts);
 		if (oConvertUtils.isNotEmpty(filterSql)) {
-			SqlInjectionUtil.specialFilterContentForDictSql(filterSql);
+			// 服务端内部拼接的 IN / LIKE 片段，走黑名单
+			SqlInjectionUtil.filterDictSqlKeywordBlacklist(filterSql);
 		}
 
 		// ---------- 4. 分页查询 ----------


### PR DESCRIPTION
## Summary
- Require JWT on dictionary/table-dict APIs **before** static-resource anonymous Shiro rules, so those endpoints cannot skip auth via static-looking paths.
- Whitelist `filterSql` to simple field comparisons / `IN` lists (existing keyword blacklist kept as defense in depth).
- Add unit tests for filter-chain order and the whitelist. 13 tests passed in `jeecg-boot-base-core`.

Fixes https://github.com/jeecgboot/JeecgBoot/issues/9840

## Test plan
- [ ] `mvn -pl jeecg-boot-base-core test -Dtest=Issue9840_DictFilterSqlWhitelistTest,Issue9840_ShiroDictJwtFilterOrderTest`
- [ ] Unauthenticated dictionary item requests fail closed
- [ ] Legitimate filters such as `del_flag=0` and `status='1'` still work after login