### PR TITLE
fix: BasicModal adaptive height overflows the viewport (#9850)

### DIFF
--- a/jeecgboot-vue3/src/components/Modal/src/BasicModal.vue
+++ b/jeecgboot-vue3/src/components/Modal/src/BasicModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal v-bind="getBindValue" @cancel="handleCancel">
+  <Modal v-bind="getBindValue" @cancel="handleCancel" @afterOpenChange="handleAfterOpenChange">
     <template #closeIcon v-if="!$slots.closeIcon">
       <ModalClose :canFullscreen="getProps.canFullscreen" :fullScreen="fullScreenRef" :commentSpan="commentSpan" :enableComment="getProps.enableComment" @comment="handleComment" @cancel="handleCancel" @fullscreen="handleFullScreen" />
     </template>
@@ -182,6 +182,9 @@
           emit('update:open', v);
           instance && modalMethods.emitVisible?.(v, instance.uid);
           nextTick(() => {
+            if (v && unref(modalWrapperRef)) {
+              (unref(modalWrapperRef) as any).setModalHeight?.();
+            }
             if (props.scrollTop && v && unref(modalWrapperRef)) {
               (unref(modalWrapperRef) as any).scrollTop();
             }
@@ -246,6 +249,15 @@
         handleFullScreen(e);
       }
 
+      // Recalc after enter animation so getBoundingClientRect is stable (antd 4).
+      function handleAfterOpenChange(open: boolean) {
+        if (open) {
+          nextTick(() => {
+            modalMethods.redoModalHeight();
+          });
+        }
+      }
+
       // 代码逻辑说明: modal支持评论 slot
       const commentSpan = ref(0);
       watch(()=>props.enableComment, (flag)=>{
@@ -287,6 +299,7 @@
         handleExtHeight,
         handleHeightChange,
         handleTitleDbClick,
+        handleAfterOpenChange,
         getWrapperHeight,
         commentSpan,
         handleComment,

--- a/jeecgboot-vue3/src/components/Modal/src/components/ModalWrapper.vue
+++ b/jeecgboot-vue3/src/components/Modal/src/components/ModalWrapper.vue
@@ -12,6 +12,7 @@
   import { ScrollContainer } from '/@/components/Container';
   import { createModalContext } from '../hooks/useModalContext';
   import { useMutationObserver } from '@vueuse/core';
+  import { computeModalBodyMaxHeight, resolveModalTop } from '../utils/modalHeight';
 
   const props = {
     loading: { type: Boolean },
@@ -77,6 +78,7 @@
               },
               {
                 attributes: true,
+                childList: true,
                 subtree: true,
               }
             );
@@ -114,10 +116,15 @@
               };
             }
           } else {
+            const minH = props.minHeight === null ? defaultMiniHeight : props.minHeight;
+            const available = unref(availableHeightRef) || unref(realHeightRef) || minH;
+            const cap = props.maxHeight
+              ? Math.min(props.maxHeight, available || props.maxHeight)
+              : (unref(realHeightRef) || available);
             return {
-              minHeight: `${props.minHeight === null ? defaultMiniHeight : props.minHeight}px`,
-              // 代码逻辑说明: 【QQYUN-7641】basicModal组件添加MaxHeight属性
-              maxHeight: `${props.maxHeight ? Math.min(props.maxHeight, unref(availableHeightRef) || props.maxHeight) : unref(realHeightRef)}px`,
+              minHeight: `${minH}px`,
+              // 代码逻辑说明: 【QQYUN-7641】basicModal组件添加MaxHeight属性 / 【issues/9850】未设置 height 时用视口可用高度封顶
+              maxHeight: `${Math.max(cap, minH)}px`,
             };
           }
         }
@@ -157,7 +164,6 @@
       }
 
       async function setModalHeight(option?) {
-        console.log("---------性能监控--------setModalHeight----------")
         const options = option || {};
         const source = options.source;
         const callBack = options.callBack;
@@ -166,38 +172,35 @@
         if (!props.visible) return;
         const wrapperRefDom = unref(wrapperRef);
         if (!wrapperRefDom) return;
-        // 代码逻辑说明: 【QQYUN-8573】BasicModal组件在非全屏的情况下最大高度获取异常，不论内容高度是否超出屏幕高度，都等于内容高度
-        const bodyDom = wrapperRefDom.$el.parentElement?.parentElement?.parentElement;
-        if (!bodyDom) return;
-        // bodyDom.style.padding = '0';
+        const spinEl = unref(spinRef);
+        if (!spinEl) return;
         await nextTick();
 
         try {
-          const modalDom = bodyDom.closest('.ant-modal');
+          const modalDom = (spinEl as HTMLElement).closest('.ant-modal') as HTMLElement | null;
           if (!modalDom) return;
-          //update-begin---author:scott ---date:20260814  for:修复弹窗内容高度自适应及底部操作按钮遮挡问题-----------
-          const spinEl = unref(spinRef);
-          if (!spinEl) return;
 
-          // 使用 CSS 布局位置计算可用高度，避免打开动画导致位置读取不稳定
-          const modalTop = Number.parseFloat(getComputedStyle(modalDom).top) || 0;
-          const modalExtHeight = (modalDom as HTMLElement).offsetHeight - spinEl.clientHeight;
-          let maxHeight = window.innerHeight - modalTop + (props.footerOffset! || 0) - modalExtHeight;
-          //update-end---author:scott ---date:20260814  for:修复弹窗内容高度自适应及底部操作按钮遮挡问题-----------
+          const headerEl = modalDom.querySelector('.ant-modal-header') as HTMLElement | null;
+          const footerEl = modalDom.querySelector('.ant-modal-footer') as HTMLElement | null;
+          const headerHeight = headerEl?.offsetHeight || (props.modalHeaderHeight ?? 0);
+          const footerHeight = footerEl?.offsetHeight || (props.modalFooterHeight ?? 0);
 
-          // 距离顶部过进会出现滚动条
-          if (modalTop < 40) {
-            maxHeight -= 26;
-          }
+          // CSS top in px is stable during enter animation; painted rect is the fallback (antd 4 inner wrap / centered)
+          const modalTop = resolveModalTop(getComputedStyle(modalDom).top, modalDom.getBoundingClientRect().top);
+          let maxHeight = computeModalBodyMaxHeight({
+            viewportHeight: window.innerHeight,
+            modalTop,
+            headerHeight,
+            footerHeight,
+            footerOffset: props.footerOffset || 0,
+          });
+
           availableHeightRef.value = maxHeight;
           await nextTick();
-          await nextTick();
-          // if (!realHeight) {
           realHeight = spinEl.scrollHeight;
-          // }
 
           if (props.fullScreen) {
-            realHeightRef.value = window.innerHeight - props.modalFooterHeight - props.modalHeaderHeight - 28;
+            realHeightRef.value = window.innerHeight - footerHeight - headerHeight - 28;
           } else {
             realHeightRef.value = props.height ? props.height : realHeight > maxHeight ? maxHeight : realHeight;
           }
@@ -205,7 +208,7 @@
           if (source == 'muob') {
             callBack(realHeightRef.value);
           }
-          
+
           emit('height-change', unref(realHeightRef));
         } catch (error) {
           console.log(error);

--- a/jeecgboot-vue3/src/components/Modal/src/hooks/useModalFullScreen.ts
+++ b/jeecgboot-vue3/src/components/Modal/src/hooks/useModalFullScreen.ts
@@ -12,7 +12,8 @@ export function useFullScreen(context: UseFullScreenContext) {
 
   const getWrapClassName = computed(() => {
     const clsName = unref(context.wrapClassName) || '';
-    return unref(fullScreenRef) ? `fullscreen-modal ${clsName} ` : unref(clsName);
+    const base = `jeecg-basic-modal-wrap ${clsName}`.trim();
+    return unref(fullScreenRef) ? `fullscreen-modal ${base} ` : base;
   });
 
   function handleFullScreen(e: Event) {

--- a/jeecgboot-vue3/src/components/Modal/src/index.less
+++ b/jeecgboot-vue3/src/components/Modal/src/index.less
@@ -27,6 +27,26 @@
   }
 }
 
+// 代码逻辑说明: 【issues/9850】BasicModal 非全屏时用视口高度封顶，内容滚动、footer 保持可见
+.ant-modal-root .jeecg-basic-modal-wrap:not(.fullscreen-modal) {
+  .ant-modal {
+    max-height: calc(100vh - 24px);
+  }
+
+  .ant-modal-content {
+    max-height: inherit;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .ant-modal-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+}
+
 .ant-modal {
   width: 520px;
   padding-bottom: 0;

--- a/jeecgboot-vue3/src/components/Modal/src/utils/modalHeight.ts
+++ b/jeecgboot-vue3/src/components/Modal/src/utils/modalHeight.ts
@@ -1,0 +1,58 @@
+/**
+ * Viewport-aware modal body height helpers.
+ * Used by ModalWrapper so long content scrolls and footer buttons stay on screen.
+ * Fixes #9850
+ */
+
+/** Parse a CSS pixel value; ignore percent/auto/empty so antd centered `top: 50%` is not treated as 50px. */
+export function parseCssPx(value?: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.endsWith('px')) {
+    return null;
+  }
+  const n = Number.parseFloat(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve the modal's visual offset from the top of the viewport.
+ * Prefer a concrete CSS `top` in px (stable during enter animation); otherwise use the painted rect.
+ */
+export function resolveModalTop(cssTop?: string | null, rectTop = 0, fallback = 100): number {
+  const parsed = parseCssPx(cssTop);
+  if (parsed != null && parsed > 0) {
+    return parsed;
+  }
+  if (rectTop > 1) {
+    return rectTop;
+  }
+  return fallback;
+}
+
+export interface ModalBodyMaxHeightOptions {
+  viewportHeight: number;
+  modalTop: number;
+  headerHeight: number;
+  footerHeight: number;
+  footerOffset?: number;
+  extraGap?: number;
+}
+
+/**
+ * Max height for the modal body/content area so header + footer remain inside the viewport.
+ * Bottom gap mirrors the top offset (antd default 100px) with a 24px floor.
+ */
+export function computeModalBodyMaxHeight(opts: ModalBodyMaxHeightOptions): number {
+  const bottomGap = Math.max(opts.modalTop, 24);
+  const extra = (opts.footerOffset || 0) + (opts.extraGap || 0);
+  let maxHeight =
+    opts.viewportHeight - opts.modalTop - bottomGap - opts.headerHeight - opts.footerHeight - extra;
+  // Original fudge: very small top offset tends to produce a window scrollbar.
+  if (opts.modalTop < 40) {
+    maxHeight -= 26;
+  }
+  return Math.max(Math.floor(maxHeight), 100);
+}


### PR DESCRIPTION
## Summary
- BasicModal adaptive height did not stay inside the viewport: long content stretched the dialog and hid the footer (reproduced on the 组件示例 / 弹窗扩展 “自适应高度” demo).
- Cap the modal body to the remaining viewport (header/footer reserved, bottom gap mirrored with top), scroll overflow, and recompute height after the open animation.
- CSS fallback on BasicModal wraps only, so native `a-modal` / confirm dialogs are unchanged.

Fixes #9850

## Test plan
- [ ] Open 组件示例 → 弹框抽屉 → 弹窗扩展 → “自适应高度”
- [ ] Confirm the dialog fits the window, inner content scrolls, and 确定/取消 stay visible
- [ ] Toggle fullscreen / restore and reopen; height should still fit
- [ ] Short-content modals (e.g. 内外同时显示隐藏) should still shrink to content