### PR TITLE
fix: BasicDrawer footer visibility and height stay in sync (#9793)

### DIFF
--- a/jeecgboot-vue3/src/components/Drawer/src/BasicDrawer.vue
+++ b/jeecgboot-vue3/src/components/Drawer/src/BasicDrawer.vue
@@ -14,7 +14,7 @@
     <ScrollContainer :style="getScrollContentStyle" v-loading="getLoading" :loading-tip="loadingText || t('common.loadingText')">
       <slot></slot>
     </ScrollContainer>
-    <DrawerFooter v-bind="getProps" @close="onClose" @ok="handleOk" :height="getFooterHeight">
+    <DrawerFooter v-bind="getProps" :showFooter="hasFooterContent" @close="onClose" @ok="handleOk" :height="getFooterHeight">
       <template #[item]="data" v-for="item in Object.keys($slots)">
         <slot :name="item" v-bind="data || {}"></slot>
       </template>
@@ -42,7 +42,7 @@
     inheritAttrs: false,
     props: basicProps,
     emits: ['visible-change', 'open-change', 'ok', 'close', 'register'],
-    setup(props, { emit }) {
+    setup(props, { emit, slots }) {
       const visibleRef = ref(false);
       const attrs = useAttrs();
       const propsRef = ref<Partial<Nullable<DrawerProps>>>(null);
@@ -97,10 +97,16 @@
         };
       });
 
-      // Custom implementation of the bottom button,
+      // Footer is visible when showFooter is set OR any footer slot is provided.
+      // insertFooter/centerFooter/appendFooter previously did not reserve height or even render.
+      const hasFooterContent = computed(() => {
+        const { showFooter } = unref(getProps);
+        return !!(showFooter || slots.footer || slots.insertFooter || slots.centerFooter || slots.appendFooter);
+      });
+
       const getFooterHeight = computed(() => {
-        const { footerHeight, showFooter } = unref(getProps);
-        if (showFooter && footerHeight) {
+        const { footerHeight } = unref(getProps);
+        if (unref(hasFooterContent) && footerHeight) {
           return isNumber(footerHeight) ? `${footerHeight}px` : `${footerHeight.replace('px', '')}px`;
         }
         return `0px`;
@@ -183,6 +189,7 @@
         getLoading,
         getBindValues,
         getFooterHeight,
+        hasFooterContent,
         handleOk,
       };
     },

--- a/jeecgboot-vue3/src/components/Drawer/src/components/DrawerFooter.vue
+++ b/jeecgboot-vue3/src/components/Drawer/src/components/DrawerFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="prefixCls" :style="getStyle" v-if="showFooter || $slots.footer">
+  <div :class="prefixCls" :style="getStyle" v-if="showFooter || $slots.footer || $slots.insertFooter || $slots.centerFooter || $slots.appendFooter">
     <template v-if="!$slots.footer">
       <slot name="insertFooter"></slot>
       <a-button v-bind="cancelButtonProps" @click="handleClose" class="mr-2" v-if="showCancelBtn">


### PR DESCRIPTION
## Summary
- BasicDrawer footer only rendered when `showFooter` was set, so `insertFooter` / `centerFooter` / `appendFooter` slots were ignored and a custom `#footer` did not reserve body height.
- Footer render and content height now use the same condition (`showFooter` or any footer slot). Existing list/detail drawers that omit `showFooter` still have no default OK/Cancel buttons.

Fixes #9793

## Test plan
- [ ] Open a drawer that only uses `#insertFooter` / `#centerFooter` / `#appendFooter` (no `showFooter`) and confirm the footer renders
- [ ] Open a drawer with a custom `#footer` and confirm the body is not covered
- [ ] Existing drawers that already pass `showFooter` still show 取消/确定
- [ ] Detail/list drawers that never passed `showFooter` still have no extra buttons