### PR TITLE
fix: queryTreeListNoPage returns matched nodes instead of only roots (#9799)

### DIFF
--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/jeecg/code-template-online/default/tree/java/${bussiPackage}/${entityPackage}/controller/${entityName}Controller.javai
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/jeecg/code-template-online/default/tree/java/${bussiPackage}/${entityPackage}/controller/${entityName}Controller.javai
@@ -90,7 +90,7 @@ public class ${entityName}Controller extends JeecgController<${entityName}, I${e
         if(hasQuery != null && "true".equals(hasQuery)){
             QueryWrapper<${entityName}> queryWrapper =  QueryGenerator.initQueryWrapper(${entityName?uncap_first}, req.getParameterMap());
             List<${entityName}> list = ${entityName?uncap_first}Service.queryTreeListNoPage(queryWrapper);
-            IPage<${entityName}> pageList = new Page<>(1, 10, list.size());
+            IPage<${entityName}> pageList = new Page<>(1, Math.max(list.size(), 1), list.size());
             pageList.setRecords(list);
             return Result.OK(pageList);
         }else{

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/jeecg/code-template-online/default/tree/java/${bussiPackage}/${entityPackage}/service/impl/${entityName}ServiceImpl.javai
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/resources/jeecg/code-template-online/default/tree/java/${bussiPackage}/${entityPackage}/service/impl/${entityName}ServiceImpl.javai
@@ -12,7 +12,9 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 <#assign pidFieldName = "">
@@ -114,18 +116,23 @@ public class ${entityName}ServiceImpl extends ServiceImpl<${entityName}Mapper, $
     public List<${entityName}> queryTreeListNoPage(QueryWrapper<${entityName}> queryWrapper) {
         List<${entityName}> dataList = baseMapper.selectList(queryWrapper);
         List<${entityName}> mapList = new ArrayList<>();
-        for(${entityName} data : dataList){
+        if (dataList == null || dataList.isEmpty()) {
+            return mapList;
+        }
+        // 条件查询时应返回命中节点本身（父节点不在结果集中的作为顶层），而不是一律回溯到全局根节点
+        Set<String> idSet = new HashSet<>();
+        for (${entityName} data : dataList) {
+            if (data.getId() != null) {
+                idSet.add(data.getId());
+            }
+        }
+        for (${entityName} data : dataList) {
             String pidVal = data.get${pidFieldName?cap_first}();
-            //递归查询子节点的根节点
-            if(pidVal != null && !I${entityName}Service.NOCHILD.equals(pidVal)){
-                ${entityName} rootVal = this.getTreeRoot(pidVal);
-                if(rootVal != null && !mapList.contains(rootVal)){
-                    mapList.add(rootVal);
-                }
-            }else{
-                if(!mapList.contains(data)){
-                    mapList.add(data);
-                }
+            boolean parentMissing = pidVal == null
+                    || I${entityName}Service.ROOT_PID_VALUE.equals(pidVal)
+                    || !idSet.contains(pidVal);
+            if (parentMissing && !mapList.contains(data)) {
+                mapList.add(data);
             }
         }
         return mapList;


### PR DESCRIPTION
## Summary
- Tree list searches (`hasQuery=true`) always walked hits back to the global root, so condition queries returned a single root instead of the matched records.
- `queryTreeListNoPage` now returns the matched forest (nodes whose parent is not also in the result), and the no-page API uses the result size instead of a hardcoded page of 10.

Fixes #9799

## Test plan
- [ ] Generate a tree entity from the online tree template and search with a name condition that matches non-root rows
- [ ] Confirm the list shows those matched rows, not only the global root
- [ ] Confirm more than 10 hits are all returned
- [ ] Expanding the tree without a query still loads children by parent id as before