### PR TITLE
fix: gateway keeps routing to deregistered instances (#9679)

### DIFF
--- a/jeecg-boot/jeecg-server-cloud/jeecg-cloud-gateway/src/main/resources/application.yml
+++ b/jeecg-boot/jeecg-server-cloud/jeecg-cloud-gateway/src/main/resources/application.yml
@@ -27,6 +27,14 @@ spring:
         namespace: @config.namespace@
         username: @config.username@
         password: @config.password@
+        watch:
+          enabled: true
+    # 默认 LoadBalancer 实例缓存会让已下线节点在网关侧残留
+    loadbalancer:
+      cache:
+        enabled: false
+      nacos:
+        enabled: true
     gateway:
       server:
         webflux:

--- a/jeecg-boot/jeecg-server-cloud/jeecg-cloud-nacos/docs/DEFAULT_GROUP/jeecg-gateway.yaml
+++ b/jeecg-boot/jeecg-server-cloud/jeecg-cloud-nacos/docs/DEFAULT_GROUP/jeecg-gateway.yaml
@@ -5,6 +5,12 @@ jeecg:
       data-type: database
       data-id: jeecg-gateway-router
 spring:
+  cloud:
+    loadbalancer:
+      cache:
+        enabled: false
+      nacos:
+        enabled: true
   data:
     redis:
       database: 0


### PR DESCRIPTION
## Summary
- Gateway kept sending traffic to instances that Nacos had already removed, because Spring Cloud LoadBalancer caches the instance list by default.
- Disable that cache, enable Nacos load balancing, and turn on discovery watch so instance up/down is applied immediately.

Fixes #9679

## Test plan
- [ ] Start two system instances behind the gateway, stop one, and confirm Nacos no longer lists it
- [ ] Confirm subsequent gateway requests only hit the remaining instance (no connection-refused to the stopped one)
- [ ] Restart the stopped instance and confirm it is routed again without restarting the gateway